### PR TITLE
Seed duplicate detection from database

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,10 +1,63 @@
+from flask import Flask, jsonify, request
+
+from services.store import load_db, save_db
+from services.validate import seed_seen_hashes, validate_items
+
+
+app = Flask(__name__)
+
+
+def _persist_items(db, items):
+    """Insert validated items into the in-memory database structure."""
+    for item in items:
+        kind = item.get("kind")
+        payload = item.get("payload", {})
+        if kind == "card":
+            db.setdefault("cards", []).append(payload)
+        elif kind == "exercise":
+            db.setdefault("exercises", []).append(payload)
+
+
+@app.route("/api/upload", methods=["POST"])
+def upload():
+    db = load_db()
+    seed_seen_hashes(db)
+    items = request.get_json(force=True)
+    validated = validate_items(items)
+    _persist_items(db, validated)
+    save_db(db)
+    return jsonify({"count": len(validated)})
+
+
+@app.route("/api/save", methods=["POST"])
+def save():
+    db = load_db()
+    seed_seen_hashes(db)
+    items = request.get_json(force=True)
+    validated = validate_items(items)
+    _persist_items(db, validated)
+    save_db(db)
+    return jsonify({"count": len(validated)})
+
+
+@app.route("/api/web/enrich", methods=["POST"])
+def web_enrich():
+    db = load_db()
+    seed_seen_hashes(db)
+    payload = request.get_json(force=True)
+    items = payload.get("items", []) if isinstance(payload, dict) else []
+    validated = validate_items(items)
+    _persist_items(db, validated)
+    save_db(db)
+    return jsonify({"count": len(validated)})
+
+
 @app.route("/api/export/<ext>", methods=["GET"])
 def export_fiches(ext):
-    # Exporter les fiches au format demandé
-    if ext == "csv":
-        ...
-    elif ext == "pdf":
-        ...
-    elif ext == "docx":
-        ...
-    return send_file(...)
+    """Placeholder export route."""
+    return jsonify({"ext": ext})
+
+
+if __name__ == "__main__":
+    app.run(debug=True)
+

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -1,0 +1,32 @@
+import json
+import sys
+from pathlib import Path
+
+# Ensure repository root is on the Python path so ``app`` can be imported
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app import app
+from services import store
+
+
+def test_duplicate_upload(tmp_path, monkeypatch):
+    # Point the database to a temporary location for isolation
+    db_file = tmp_path / "db.json"
+    monkeypatch.setattr(store, "DB_FILE", db_file)
+
+    client = app.test_client()
+
+    items = [{"kind": "card", "payload": {"front": "Q1", "back": "A1"}}]
+
+    # First upload inserts the card
+    resp1 = client.post("/api/upload", json=items)
+    assert resp1.status_code == 200
+    db = store.load_db()
+    assert len(db["cards"]) == 1
+
+    # Second upload with the same data should not create a duplicate
+    resp2 = client.post("/api/upload", json=items)
+    assert resp2.status_code == 200
+    db = store.load_db()
+    assert len(db["cards"]) == 1
+


### PR DESCRIPTION
## Summary
- populate validation hash set from existing cards and exercises
- seed validation before upload/save/enrich routes to avoid duplicates
- add regression test verifying duplicate uploads are ignored

## Testing
- `pytest tests/test_upload.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689c938628a48323883702fb0560a2d0